### PR TITLE
libmatchies: Decouple te attribs (named values)

### DIFF
--- a/lib/matchd_lib.c
+++ b/lib/matchd_lib.c
@@ -1855,22 +1855,22 @@ done:
 }
 
 static int(*type_cb[NET_MAT_CMD_MAX+1])(struct nlmsghdr *nlh) = {
-	match_cmd_get_tables,
-	match_cmd_get_headers,
-	match_cmd_get_actions,
-	match_cmd_get_header_graph,
-	match_cmd_get_table_graph,
-	match_cmd_get_rules,
-	match_cmd_rules,
-	match_cmd_rules,
-	match_cmd_update_rules,
-	match_cmd_table,
-	match_cmd_table,
-	match_cmd_table,
-	match_cmd_get_ports,
-	match_cmd_get_lport,
-	match_cmd_get_phys_port,
-	match_cmd_set_ports,
+	[NET_MAT_TABLE_CMD_GET_TABLES]	    = match_cmd_get_tables,
+	[NET_MAT_TABLE_CMD_GET_HEADERS]	    = match_cmd_get_headers,
+	[NET_MAT_TABLE_CMD_GET_ACTIONS]	    = match_cmd_get_actions,
+	[NET_MAT_TABLE_CMD_GET_HDR_GRAPH]   = match_cmd_get_header_graph,
+	[NET_MAT_TABLE_CMD_GET_TABLE_GRAPH] = match_cmd_get_table_graph,
+	[NET_MAT_TABLE_CMD_GET_RULES]	    = match_cmd_get_rules,
+	[NET_MAT_TABLE_CMD_SET_RULES]	    = match_cmd_rules,
+	[NET_MAT_TABLE_CMD_DEL_RULES]	    = match_cmd_rules,
+	[NET_MAT_TABLE_CMD_UPDATE_RULES]    = match_cmd_update_rules,
+	[NET_MAT_TABLE_CMD_CREATE_TABLE]    = match_cmd_table,
+	[NET_MAT_TABLE_CMD_DESTROY_TABLE]   = match_cmd_table,
+	[NET_MAT_TABLE_CMD_UPDATE_TABLE]    = match_cmd_table,
+	[NET_MAT_PORT_CMD_GET_PORTS]	    = match_cmd_get_ports,
+	[NET_MAT_PORT_CMD_GET_LPORT]	    = match_cmd_get_lport,
+	[NET_MAT_PORT_CMD_GET_PHYS_PORT]    = match_cmd_get_phys_port,
+	[NET_MAT_PORT_CMD_SET_PORTS]	    = match_cmd_set_ports,
 };
 
 int matchd_rx_process(struct nlmsghdr *nlh)

--- a/models/ies_pipeline.h
+++ b/models/ies_pipeline.h
@@ -1385,33 +1385,50 @@ static struct net_mat_tbl my_table_tcam = {
 #define IES_VXLAN_DST_MAC 3
 #define IES_VXLAN_MISS_DFLT_PORT 4
 
-static struct net_mat_named_value values_tunnel_engine[] = {
-	{ .name = vxlan_src_port_str,
-	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_VXLAN_SRC_PORT,
-	  .type = NET_MAT_NAMED_VALUE_TYPE_U32,
-	  .value.u32 = IES_VXLAN_PORT,
-	  .write = 0},
-	{ .name = vxlan_dst_port_str,
-	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_VXLAN_DST_PORT,
-	  .type = NET_MAT_NAMED_VALUE_TYPE_U32,
-	  .value.u32 = IES_VXLAN_PORT,
-	  .write = 0},
-	{ .name = vxlan_src_mac_str,
-	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_VXLAN_SRC_MAC,
-	  .type = NET_MAT_NAMED_VALUE_TYPE_U64,
-	  .value.u64 = IES_ROUTER_MAC,
-	  .write = NET_MAT_NAMED_VALUE_IS_WRITABLE},
-	{ .name = vxlan_dst_mac_str,
-	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_VXLAN_DST_MAC,
-	  .type = NET_MAT_NAMED_VALUE_TYPE_U64,
-	  .value.u64 = IES_ROUTER_MAC,
-	  .write = NET_MAT_NAMED_VALUE_IS_WRITABLE},
-	{ .name = te_miss_dflt_port_str,
-	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_MISS_DFLT_EGRESS_PORT,
-	  .type = NET_MAT_NAMED_VALUE_TYPE_U16,
-	  .value.u16 = 0,
-	  .write = NET_MAT_NAMED_VALUE_IS_WRITABLE},
+#define IES_TABLE_TUNNEL_NAMED_VALUE_DEFAULT_INITIALIZER		\
+	{ .name = vxlan_src_port_str,					\
+	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_VXLAN_SRC_PORT,		\
+          .type = NET_MAT_NAMED_VALUE_TYPE_U32,				\
+	  .value.u32 = IES_VXLAN_PORT,					\
+	  .write = 0},							\
+	{ .name = vxlan_dst_port_str,					\
+	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_VXLAN_DST_PORT,		\
+	  .type = NET_MAT_NAMED_VALUE_TYPE_U32,				\
+	  .value.u32 = IES_VXLAN_PORT,					\
+	  .write = 0},							\
+	[IES_VXLAN_SRC_MAC] =						\
+	{ .name = vxlan_src_mac_str,					\
+	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_VXLAN_SRC_MAC,		\
+	  .type = NET_MAT_NAMED_VALUE_TYPE_U64,				\
+	  .value.u64 = IES_ROUTER_MAC,					\
+	  .write = NET_MAT_NAMED_VALUE_IS_WRITABLE},			\
+	[IES_VXLAN_DST_MAC] =						\
+	{ .name = vxlan_dst_mac_str,					\
+	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_VXLAN_DST_MAC,		\
+	  .type = NET_MAT_NAMED_VALUE_TYPE_U64,				\
+	  .value.u64 = IES_ROUTER_MAC,					\
+	  .write = NET_MAT_NAMED_VALUE_IS_WRITABLE},			\
+	[IES_VXLAN_MISS_DFLT_PORT] =					\
+	{ .name = te_miss_dflt_port_str,				\
+	  .uid = NET_MAT_TABLE_ATTR_NAMED_VALUE_MISS_DFLT_EGRESS_PORT,	\
+	  .type = NET_MAT_NAMED_VALUE_TYPE_U16,				\
+	  .value.u16 = 0,						\
+	  .write = NET_MAT_NAMED_VALUE_IS_WRITABLE},			\
 	{ .name = NULL, .uid = 0 },
+
+
+static struct net_mat_named_value values_tunnel_engine_a[] = {
+	IES_TABLE_TUNNEL_NAMED_VALUE_DEFAULT_INITIALIZER
+};
+
+static struct net_mat_named_value values_tunnel_engine_b[] = {
+	IES_TABLE_TUNNEL_NAMED_VALUE_DEFAULT_INITIALIZER
+};
+
+
+static struct net_mat_named_value * const values_tunnel_engine[] = {
+	values_tunnel_engine_a,
+	values_tunnel_engine_b,
 };
 
 static struct net_mat_tbl my_table_tunnel_a = {
@@ -1422,10 +1439,10 @@ static struct net_mat_tbl my_table_tunnel_a = {
 	.size = TABLE_TUNNEL_ENDPOINT_SIZE,
 	.matches = matches_tunnel_engine,
 	.actions = actions_tunnel_engine,
-	.attribs = values_tunnel_engine,
+	.attribs = values_tunnel_engine_a,
 };
 
-static struct net_mat_tbl my_table_tunnel_b= {
+static struct net_mat_tbl my_table_tunnel_b = {
 	.name = tunnel_engine_b,
 	.uid = TABLE_TUNNEL_ENGINE_B,
 	.source = TABLE_TUNNEL_ENGINE_B,
@@ -1433,7 +1450,7 @@ static struct net_mat_tbl my_table_tunnel_b= {
 	.size = TABLE_TUNNEL_ENDPOINT_SIZE,
 	.matches = matches_tunnel_engine,
 	.actions = actions_tunnel_engine,
-	.attribs = values_tunnel_engine,
+	.attribs = values_tunnel_engine_b,
 };
 
 #ifdef PORT_TO_VNI


### PR DESCRIPTION
ONP-3552

Decouple tunnel engines named value attributes.
Tunnel engines table (my_table_tunnel_{a,b}) used to share common
values_tunnel_engine via their attribs pointer. The outcome was
that changing attribute of one tunnel engine was reflected and affecting
the other table.
Ideally the pipeline model should be read-only and defined const.
It should only define the supported table attributes and their
properties (e.g. name, value, value type, writable, default value).
However, the current implementation does not separate the supported
attributes definition from assigned values of writable attributes.
Moreover, there are multiple code paths that could access those
attribute values (some via a net_mat_tbl structure).
This patch attempts to decouple table attributes of tunnel engines
with minimal code changes. It avoids the need to follow and possibly
alter all references to table attributes.
A separate net_mat_named_value structure is
defined for each tunnel engine (values_tunnel_engine_{a,b}) and set as
the attribs field of the respective my_table_tunnel_{a,b}.
values_tunnel_engine is modified from an array of struct
net_mat_named_value to a two items array of pointers to the tunnel
engines values. This allows the code changes to be limited to accessing
tunnel values via indexing by the tunnel engine index.
The two tunnel engines remains synced in their supported attributes
using a common initializer macro which is used to initialized both.

Signed-off-by: Ronen Arad <ronen.arad@intel.com>