### PR TITLE
matchd: Refactor netlink recv in matchd and libmatchd

### DIFF
--- a/include/matchd_lib.h
+++ b/include/matchd_lib.h
@@ -35,4 +35,6 @@ int matchd_init(struct nl_sock *sock, int family_id, const char *backend_name,
 int matchd_uninit(void);
 int matchd_rx_process(struct nlmsghdr *nlh);
 
+int matchd_receive_loop(struct nl_sock *sock);
+
 #endif /* __MATCHD_LIB_H__ */


### PR DESCRIPTION
This patch replaces the receive loop within matchd.c:main() with
a call to a new function matchd_receive_loop() within libmatchd.
The objective is to replace nl_recv() with nl_recvmsgs_default()
and thus allow for protocol debugging of matchd using NLCB=debug.
The logic of matchd_receive_loop() is similar to the logic some
clients already use.

Signed-off-by: Ronen Arad <ronen.arad@intel.com>