### PR TITLE
ieslib: Extend parsing beyond L2 up to L4 on CPU port

### DIFF
--- a/lib/ieslib.c
+++ b/lib/ieslib.c
@@ -1846,7 +1846,13 @@ int switch_init(bool one_vlan)
 
 	MAT_LOG(DEBUG, "set pvid for  port %d to vlan %u\n", port, vlan);
 
-	le = FM_DISABLED;
+        err = fmSetPortAttribute(sw, port, FM_PORT_PARSER, &pc);
+        if (err != FM_OK)
+                return cleanup("fmSetPortAttribute", err);
+
+        MAT_LOG(DEBUG, "set FM_PORT_PARSER for port %d to %d\n", port, pc);
+
+        le = FM_DISABLED;
 	err = fmSetPortAttribute(sw, port, FM_PORT_LEARNING, &le);
 	if (err != FM_OK)
 		return cleanup("fmSetPortAttribute", err);


### PR DESCRIPTION
This patch set the per-port attribute for enabling L2-L4 parsing of packets
sent on the CPU port. This attribute was previousely enabled on all
ports except for the CPU port.